### PR TITLE
make an illumos package for overwatch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Set up `cargo xtask`.
+[alias]
+xtask = "run --package xtask -- "

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#:
+#: name = "overwatch-p5p"
+#: variety = "basic"
+#: target = "helios-2.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "=/out/overwatch.p5p",
+#:   "=/out/overwatch.p5p.sha256",
+#: ]
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "overwatch.p5p"
+#: from_output = "/out/overwatch.p5p"
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "overwatch.p5p.sha256"
+#: from_output = "/out/overwatch.p5p.sha256"
+#:
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+cargo --version
+rustc --version
+
+banner build
+ptime -m cargo build --release
+
+banner package
+cargo xtask package
+
+banner copy
+pfexec mkdir -p /out
+pfexec chown "$UID" /out
+PKG_NAME="/out/overwatch.p5p"
+mv pkg/packages/repo/*.p5p "$PKG_NAME"
+sha256sum "$PKG_NAME" > "$PKG_NAME.sha256"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 *.sw*
 out.rs
+/pkg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2941,6 +2947,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "indoc",
  "toml 0.8.12",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,7 +1297,7 @@ dependencies = [
  "tar",
  "thiserror 1.0.58",
  "tokio",
- "toml",
+ "toml 0.7.8",
  "topological-sort",
  "walkdir",
 ]
@@ -1496,7 +1519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1843,18 +1866,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1863,11 +1886,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -2321,7 +2345,19 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -2343,7 +2379,20 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -2835,6 +2884,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,6 +2932,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "clap",
+ "toml 0.8.12",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.2.5", features = ["derive", "unstable-styles"] }
 colored = "2.0.0"
 dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys", version = "0.2.0" }
 hex = "0.4.3"
+indoc = "2"
 macaddr = "1.0.1"
 num_enum = "0.6.1"
 p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,18 +4,25 @@ resolver = "2"
 default-members = [
     "overwatch",
     "package",
+    "xtask",
 ]
 
 members = [
     "overwatch",
     "package",
+    "xtask",
 ]
+
+[workspace.package]
+edition = "2021"
+repository = "https://github.com/oxidecomputer/overwatch"
 
 [workspace.dependencies]
 anstyle = "1.0.0"
 anyhow = "1.0.71"
 bitvec = "1.0.1"
 camino = "1.1"
+cargo_metadata = "0.19"
 clap = { version = "4.2.5", features = ["derive", "unstable-styles"] }
 colored = "2.0.0"
 dlpi = { git = "https://github.com/oxidecomputer/dlpi-sys", version = "0.2.0" }
@@ -26,4 +33,5 @@ p4-macro = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
 p4rs = { git = "https://github.com/oxidecomputer/p4", branch = "main" }
 pretty-hex = "0.3.0"
 tokio = { version = "1.43.0", features = ["full"] }
+toml = "0.8"
 usdt = "0.3.5"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,4 +8,5 @@ repository.workspace = true
 anyhow.workspace = true
 cargo_metadata.workspace = true
 clap.workspace = true
+indoc.workspace = true
 toml.workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+cargo_metadata.workspace = true
+clap.workspace = true
+toml.workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,258 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Copyright 2025 Oxide Computer Company
+
+use anyhow::Context;
+use anyhow::Result;
+use cargo_metadata::Metadata;
+use clap::Parser;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::OnceLock;
+
+static PUBLISHER: &str = "helios-dev";
+static API_VSN: u32 = 1;
+
+static METADATA: OnceLock<Metadata> = OnceLock::new();
+fn cargo_meta() -> &'static Metadata {
+    METADATA
+        .get_or_init(|| cargo_metadata::MetadataCommand::new().exec().unwrap())
+}
+
+#[derive(Debug, Parser)]
+enum Xtask {
+    /// produce an illumos package for overwatch
+    Package,
+}
+
+fn main() -> anyhow::Result<()> {
+    let cmd = Xtask::parse();
+    match cmd {
+        Xtask::Package => {
+            cmd_package()?;
+            Ok(())
+        }
+    }
+}
+
+// Remove a file or directory, if it exists.
+fn remove_if_exists<P: AsRef<Path>>(path: P) -> Result<()> {
+    match fs::metadata(&path) {
+        Ok(metadata) => {
+            let res = if metadata.is_file() {
+                fs::remove_file(&path)
+            } else if metadata.is_dir() {
+                fs::remove_dir_all(&path)
+            } else {
+                anyhow::bail!("unknown file type")
+            };
+
+            match res {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    anyhow::bail!("failed to remove: {}", e)
+                }
+            }
+        }
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                Ok(())
+            } else {
+                anyhow::bail!("failed to remove: {}", e)
+            }
+        }
+    }
+}
+
+fn cmd_package() -> Result<()> {
+    let meta = cargo_meta();
+
+    // This is the directory where the packages are made
+    let pkg_dir = meta.workspace_root.join("pkg");
+    remove_if_exists(&pkg_dir)?;
+
+    // Start by clearing out any temporary directories and ensuring
+    // that files we use are created fresh
+    let proto_dir = pkg_dir.join("proto");
+    //remove_if_exists(&proto_dir)?;
+
+    let package_dir = pkg_dir.join("packages");
+    //remove_if_exists(&package_dir)?;
+    fs::create_dir_all(&package_dir)?;
+
+    let base_p5m = pkg_dir.join("overwatch.base.p5m");
+    // remove_if_exists(&base_p5m)?;
+    println!("Create {:?}", &base_p5m);
+    let mut file = fs::File::create(&base_p5m).unwrap();
+
+    let generate_p5m = pkg_dir.join("overwatch.generate.p5m");
+    // remove_if_exists(&generate_p5m)?;
+    println!("Create {:?}", &generate_p5m);
+    let generate_file = fs::File::create(&generate_p5m).unwrap();
+
+    // Create the final file.
+    let final_p5m = pkg_dir.join("overwatch.final.p5m");
+    // remove_if_exists(&final_p5m)?;
+    println!("Create {:?}", &final_p5m);
+    let mut output_file = fs::File::create(&final_p5m)?;
+
+    // Begin the process of creating our package.
+    println!("Get git rev count");
+    let output = Command::new("git")
+        .args(["rev-list", "--count", "HEAD"])
+        .output()
+        .expect("Failed to execute git command");
+
+    // Check if the command succeeded
+    if !output.status.success() {
+        anyhow::bail!("failed to run git (status {})", output.status)
+    }
+    let commit_count: u64 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .expect("Failed to parse git output as a number");
+
+    println!("Git commit count: {}", commit_count);
+
+    println!("Make directories for packaging");
+
+    let proto_bin_dir = proto_dir.join("usr").join("bin");
+    fs::create_dir_all(&proto_bin_dir)?;
+
+    // cp ../target/release/overwatch proto/usr/bin/
+    let source = meta
+        .workspace_root
+        .join("target")
+        .join("release")
+        .join("overwatch");
+
+    let destination = proto_bin_dir.join("overwatch");
+
+    println!("Now copy {:?} to {:?}", source, destination);
+    fs::copy(&source, &destination)?;
+
+    // Define the file content as a multi-line string
+    let content = format!("\
+set name=pkg.fmri value=pkg://{}/overwatch@0.{}.{}
+set name=pkg.summary value=\"Overwatch packet inspection tool\"
+set name=info.classification value=org.opensolaris.category.2008:Network/Application
+set name=variant.opensolaris.zone value=global value=nonglobal
+set name=variant.arch value=i386
+file NOHASH group=bin mode=0755 owner=root path=usr/bin/overwatch
+", PUBLISHER, API_VSN, commit_count);
+
+    file.write_all(content.as_bytes()).unwrap();
+
+    println!("File created successfully at {}", base_p5m);
+
+    // pkgdepend generate -d proto overwatch.base.p5m > overwatch.generate.p5m
+
+    let mut cmd = Command::new("pkgdepend");
+    let status = cmd
+        .arg("generate")
+        .arg("-d")
+        .arg(&proto_dir)
+        .arg(&base_p5m)
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .stdout(Stdio::from(generate_file))
+        .spawn()
+        .context("failed to spawn pkgdepend 1")?
+        .wait()
+        .context("Failed to run pkgdepend")?;
+
+    if !status.success() {
+        anyhow::bail!("failed to run (status {status})")
+    }
+
+    // pkgdepend resolve -d packages -s resolve.p5m overwatch.generate.p5m
+    let mut cmd = Command::new("pkgdepend");
+    cmd.arg("resolve")
+        .arg("-d")
+        .arg(&package_dir)
+        .arg("-s")
+        .arg("resolve.p5m")
+        .arg(&generate_p5m)
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .output_nocapture()?;
+
+    // cat overwatch.base.p5m
+    //    packages/overwatch.generate.p5m.resolve.p5m > overwatch.final.p5m
+    let base = pkg_dir.join("overwatch.base.p5m");
+    let base_data = fs::read(base)?;
+
+    let resolve = pkg_dir.join("packages/overwatch.generate.p5m.resolve.p5m");
+    let resolve_data = fs::read(resolve)?;
+
+    output_file.write_all(&base_data)?;
+    output_file.write_all(&resolve_data)?;
+
+    println!("Successfully created {:?}", final_p5m);
+
+    // pkgrepo create $REPO
+    let repo_dir = package_dir.join("repo");
+    let mut cmd = Command::new("pkgrepo");
+    cmd.arg("create")
+        .arg(&repo_dir)
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .output_nocapture()?;
+
+    let mut cmd = Command::new("pkgrepo");
+    cmd.arg("add-publisher")
+        .arg("-s")
+        .arg(&repo_dir)
+        .arg(PUBLISHER)
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .output_nocapture()?;
+
+    let mut cmd = Command::new("pkgsend");
+    cmd.arg("publish")
+        .arg("-d")
+        .arg(&proto_dir)
+        .arg("-s")
+        .arg(&repo_dir)
+        .arg(final_p5m)
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .output_nocapture()?;
+
+    let final_p5p =
+        repo_dir.join(format!("overwatch-0.{}.{}.p5p", API_VSN, commit_count));
+    let mut cmd = Command::new("pkgrecv");
+    cmd.arg("-a")
+        .arg("-d")
+        .arg(final_p5p)
+        .arg("-s")
+        .arg(&repo_dir)
+        .arg("-v")
+        .arg("-m")
+        .arg("latest")
+        .arg("*")
+        .current_dir(meta.workspace_root.join(&pkg_dir))
+        .output_nocapture()?;
+
+    Ok(())
+}
+
+trait CommandNoCapture {
+    fn output_nocapture(&mut self) -> Result<()>;
+}
+
+impl CommandNoCapture for Command {
+    fn output_nocapture(&mut self) -> Result<()> {
+        let status = self
+            .spawn()
+            .context("failed to spawn child cargo invocation")?
+            .wait()
+            .context("failed to await child cargo invocation")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            anyhow::bail!("failed to run (status {status})")
+        }
+    }
+}


### PR DESCRIPTION
Created a new xtask that builds an illumos package for overwatch.

This comes from opte, but I converted the bash script into a rust program.

Example output:
```
alan@atrium:overwatch$ cargo xtask package
   Compiling xtask v0.1.0 (/home/alan/ws/overwatch/xtask)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.93s
     Running `target/debug/xtask package`
Remove and make new directories for packaging
Get git rev-list count
Git rev-list count: 39
Copy "/home/alan/ws/overwatch/target/release/overwatch" to "/home/alan/ws/overwatch/pkg/proto/usr/bin/overwatch"
Created /home/alan/ws/overwatch/pkg/overwatch.base.p5m
Successfully created "/home/alan/ws/overwatch/pkg/overwatch.final.p5m"
pkg://helios-dev/overwatch@0.1.39,5.11:20250305T202950Z
PUBLISHED
Retrieving packages for publisher helios-dev ...
Retrieving and evaluating 1 package(s)...

Archiving packages ...
        Packages to add:       1
      Files to retrieve:       1
Estimated transfer size: 2.81 MB

Packages to archive:
overwatch@0.1.39,5.11:20250305T202950Z

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1           1/1      2.8/2.8  289M/s

ARCHIVE                                              FILES  STORE (MB)
overwatch-0.1.39.p5p                               10/10     2.8/2.8
```

the `p5p` buildomat script publishes the result, and I was able to wget it and install it on an illumos system:
```
omnios@illumy:~/ov$ wget https://buildomat.eng.oxide.computer/wg/0/artefact/01JNKWV8PCM7VWGJFFPK4RM9GQ/4LRF7tsyDrwttnBxPuLdn6Vpn2UZdKYS0ZMwKRbeU99qaq2z/01JNKWVYDEN8JNVMWCYW4NGWBF/01JNKX4PPNVM15CYG6MBPZ7PMW/overwatch.p5p
--2025-03-05 20:32:12--  https://buildomat.eng.oxide.computer/wg/0/artefact/01JNKWV8PCM7VWGJFFPK4RM9GQ/4LRF7tsyDrwttnBxPuLdn6Vpn2UZdKYS0ZMwKRbeU99qaq2z/01JNKWVYDEN8JNVMWCYW4NGWBF/01JNKX4PPNVM15CYG6MBPZ7PMW/overwatch.p5p
Resolving buildomat.eng.oxide.computer... 34.220.230.66
Connecting to buildomat.eng.oxide.computer|34.220.230.66|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 2969600 (2.8M) [application/octet-stream]
Saving to: ‘overwatch.p5p’

overwatch.p5p             100%[====================================>]   2.83M  4.92MB/s    in 0.6s    

2025-03-05 20:32:13 (4.92 MB/s) - ‘overwatch.p5p’ saved [2969600/2969600]

omnios@illumy:~/ov$ pfexec pkg install -g ./overwatch.p5p overwatch
           Packages to install:  1
       Create boot environment: No
Create backup boot environment: No

DOWNLOAD                                PKGS         FILES    XFER (MB)   SPEED
Completed                                1/1           1/1      2.8/2.8  260M/s

PHASE                                          ITEMS
Installing new actions                           9/9
Updating package state database                 Done 
Updating package cache                           0/0 
Updating image state                            Done 
Creating fast lookup database                   Done 
Reading search index                            Done 
Updating search index                            1/1 
Updating package cache                           3/3 
omnios@illumy:~/ov$ 
omnios@illumy:~/ov$ which overwatch
/usr/bin/overwatch
omnios@illumy:~/ov$ overwatch
Usage: overwatch <COMMAND>

Commands:
  snoop     Snoop a packet stream
  hex-read  Read and display packets in hex format
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
  ```